### PR TITLE
Correct error in `sample()`'s `size` argument

### DIFF
--- a/R/dungeon-utils.R
+++ b/R/dungeon-utils.R
@@ -89,11 +89,8 @@
   )
 
   tiles_to_sample <- adjacent_tiles[!adjacent_tiles %in% map_edges]
-
-  new_room_tiles <- sample(
-    tiles_to_sample,
-    size = sample(length(tiles_to_sample))
-  )
+  n_to_sample <- sample(1:length(tiles_to_sample), 1)
+  new_room_tiles <- sample(tiles_to_sample, n_to_sample)
 
   m[new_room_tiles] <- "."
 


### PR DESCRIPTION
Fixes the `size` argument of `sample ()` in `.grow_dungeon()`, which was erroring when `create_dungeon()` was running in R v4.2, as discovered by @trevorld in #18.